### PR TITLE
Ensure known character set for db connection

### DIFF
--- a/core.php
+++ b/core.php
@@ -503,6 +503,7 @@ function db_conn_read_only(){
     if ($conn->connect_error) {
         die("Connection failed: " . $conn->connect_error);
     }
+    mysqli_set_charset($conn, 'utf8');
     return $conn;
 }
 
@@ -515,6 +516,7 @@ function db_conn_read_write(){
     if ($conn->connect_error) {
         die("Connection failed: " . $conn->connect_error);
     }
+    mysqli_set_charset($conn, 'utf8');
     return $conn;
 }
 


### PR DESCRIPTION
BE AWARE: This might break things if your setup is using a different character set. This is just to ensure the character set of the connection is known to the MySQL library so it can escape strings properly. If you are opening connections at other places too, they require the same treatment.